### PR TITLE
Initial AgentKit MVP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+.env
+.env.*
+.venv/
+.data/
+data/
+/tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV AGENTKIT_APP=agent_app.py
+
+EXPOSE 8080
+
+CMD ["uvicorn", "agentkit.server:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,76 @@
 # AgentKit
+
+AgentKit is a minimal "Streamlit for agents" framework. Build LangChain-powered agent apps in a single `agent_app.py` file, stream outputs to the browser, and persist runs automatically.
+
+## Features
+
+- 1-file mental model: declare inputs and agent execution in `agent_app.py` using the `agentkit.ui` DSL.
+- FastAPI + server-rendered HTML with zero frontend build steps.
+- Live token streaming, tool traces, and artifact listing over Server-Sent Events.
+- SQLite-backed persistence for runs, events, and uploaded files.
+- One-command dev server: `agentkit run agent_app.py --reload`.
+- Docker image for production (`uvicorn agentkit.server:app`).
+
+## Quickstart
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. (Optional) create a virtual environment and install AgentKit in editable mode:
+
+   ```bash
+   pip install -e .
+   ```
+
+3. Copy `.env.example` to `.env` and add your `OPENAI_API_KEY`.
+
+4. Run the example app:
+
+   ```bash
+   agentkit run agent_app.py --reload
+   ```
+
+   The server listens on [http://localhost:8080](http://localhost:8080).
+
+## Writing an agent app
+
+```python
+from agentkit import run_agent, ui
+
+with ui.page("Demo", "Ask any question"):
+    task = ui.text_input("Task")
+    attachments = ui.file_uploader("Files")
+    run = ui.button("Run Agent")
+    ui.chat()
+
+    if run and task.value:
+        run_agent({"task": task.value}, files=attachments.value)
+```
+
+Inputs become HTML form controls automatically. When the button is pressed, `run_agent` records a run, streams model output to the UI, and persists everything to SQLite.
+
+## Configuration
+
+- `agent.yaml` controls the default model and enabled tools.
+- `.env` provides environment variables such as `OPENAI_API_KEY` and `AGENTKIT_DATABASE`.
+- Uploaded files are stored in `data/uploads/` and logged in SQLite.
+
+## Testing
+
+Run the smoke test suite with `pytest`:
+
+```bash
+pytest
+```
+
+## Docker
+
+Build and run the production image:
+
+```bash
+docker build -t agentkit .
+docker run -p 8080:8080 agentkit
+```

--- a/agent.yaml
+++ b/agent.yaml
@@ -1,0 +1,8 @@
+model:
+  provider: openai
+  name: gpt-3.5-turbo
+  temperature: 0.1
+tools:
+  wikipedia: true
+  requests: true
+  python_repl: false

--- a/agent_app.py
+++ b/agent_app.py
@@ -1,0 +1,13 @@
+"""Example AgentKit application."""
+
+from agentkit import run_agent, ui
+
+
+with ui.page("AgentKit Demo", "Minimal LangChain agent template"):
+    task = ui.text_input("Task", placeholder="Ask a question or describe a task")
+    attachments = ui.file_uploader("Attachments", accept=["text/plain", "application/pdf"])
+    run_button = ui.button("Run Agent")
+    ui.chat()
+
+    if run_button and task.value:
+        run_agent({"task": task.value}, files=attachments.value)

--- a/agentkit/__init__.py
+++ b/agentkit/__init__.py
@@ -1,0 +1,6 @@
+"""AgentKit package exports."""
+
+from . import ui
+from .runner import run_agent
+
+__all__ = ["ui", "run_agent"]

--- a/agentkit/__main__.py
+++ b/agentkit/__main__.py
@@ -1,0 +1,5 @@
+from .cli import main
+
+
+if __name__ == "__main__":
+    main()

--- a/agentkit/cli.py
+++ b/agentkit/cli.py
@@ -1,0 +1,34 @@
+"""Console entry points for AgentKit."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from typing import Optional
+
+import uvicorn
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = argparse.ArgumentParser(prog="agentkit", description="AgentKit developer tools")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser("run", help="Run an AgentKit app")
+    run_parser.add_argument("app", help="Path to the agent_app.py file")
+    run_parser.add_argument("--host", default="0.0.0.0")
+    run_parser.add_argument("--port", type=int, default=8080)
+    run_parser.add_argument("--reload", action="store_true", help="Enable auto-reload")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "run":
+        app_path = Path(args.app).resolve()
+        if not app_path.exists():
+            raise SystemExit(f"App file not found: {app_path}")
+        os.environ["AGENTKIT_APP"] = str(app_path)
+        uvicorn.run("agentkit.server:app", host=args.host, port=args.port, reload=args.reload)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/agentkit/config.py
+++ b/agentkit/config.py
@@ -1,0 +1,62 @@
+"""Configuration loading utilities."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+from dotenv import load_dotenv
+
+
+@dataclass
+class ModelSettings:
+    provider: str
+    name: str
+    temperature: float = 0.0
+
+
+@dataclass
+class ToolSettings:
+    wikipedia: bool = True
+    requests: bool = True
+    python_repl: bool = False
+
+
+@dataclass
+class AgentConfig:
+    model: ModelSettings
+    tools: ToolSettings
+    raw: Dict[str, Any]
+
+
+def load_config(config_path: str | Path = "agent.yaml") -> AgentConfig:
+    load_dotenv(override=False)
+    path = Path(config_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Agent config not found at {path}")
+    data: Dict[str, Any] = yaml.safe_load(path.read_text()) or {}
+    model_cfg = data.get("model", {})
+    tool_cfg = data.get("tools", {})
+    model = ModelSettings(
+        provider=model_cfg.get("provider", "openai"),
+        name=model_cfg.get("name", "gpt-3.5-turbo"),
+        temperature=float(model_cfg.get("temperature", 0.0)),
+    )
+    tools = ToolSettings(
+        wikipedia=bool(tool_cfg.get("wikipedia", True)),
+        requests=bool(tool_cfg.get("requests", True)),
+        python_repl=bool(tool_cfg.get("python_repl", False)),
+    )
+    return AgentConfig(model=model, tools=tools, raw=data)
+
+
+def data_dir() -> Path:
+    path = Path(os.getenv("AGENTKIT_DATA", "./data"))
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+__all__ = ["AgentConfig", "ModelSettings", "ToolSettings", "load_config", "data_dir"]

--- a/agentkit/runner.py
+++ b/agentkit/runner.py
@@ -1,0 +1,113 @@
+"""LangChain agent runner used by the FastAPI server."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from langchain.callbacks.base import AsyncCallbackHandler
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_openai import ChatOpenAI
+
+from . import ui
+from .config import AgentConfig, load_config
+from .state import store
+
+
+class StreamCallbackHandler(AsyncCallbackHandler):
+    """Stream LangChain callbacks into the run store."""
+
+    def __init__(self, run_id: str) -> None:
+        self.run_id = run_id
+
+    async def on_llm_new_token(self, token: str, **kwargs: Any) -> None:  # type: ignore[override]
+        store.append_event(self.run_id, "token", {"text": token})
+
+    async def on_tool_start(self, serialized: Dict[str, Any], input_str: str, **kwargs: Any) -> None:  # type: ignore[override]
+        tool_name = serialized.get("name") or serialized.get("id") or "tool"
+        store.append_event(
+            self.run_id,
+            "tool_start",
+            {"tool": tool_name, "input": input_str},
+        )
+
+    async def on_tool_end(self, output: str, **kwargs: Any) -> None:  # type: ignore[override]
+        store.append_event(self.run_id, "tool_end", {"output": output})
+
+    async def on_llm_end(self, response, **kwargs: Any) -> None:  # type: ignore[override]
+        # Final token events are handled by the final event.
+        return
+
+
+async def _ainvoke_model(config: AgentConfig, prompt: str, run_id: str) -> str:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        message = "OPENAI_API_KEY is not configured. Returning offline stub response."
+        store.append_event(run_id, "token", {"text": message})
+        return "Unable to execute agent without API credentials."
+
+    handler = StreamCallbackHandler(run_id)
+    llm = ChatOpenAI(
+        model=config.model.name,
+        temperature=config.model.temperature,
+        streaming=True,
+        callbacks=[handler],
+    )
+    prompt_template = ChatPromptTemplate.from_messages(
+        [
+            ("system", "You are AgentKit, a helpful assistant."),
+            ("human", "{input}"),
+        ]
+    )
+    chain = prompt_template | llm | StrOutputParser()
+    result = await chain.ainvoke({"input": prompt})
+    return result
+
+
+async def _execute_run(run_id: str, inputs: Dict[str, Any], files: Optional[List[Path]]) -> None:
+    try:
+        config = load_config()
+        store.append_event(run_id, "status", {"message": "Agent started."})
+        prompt = build_prompt(inputs, files)
+        final_text = await _ainvoke_model(config, prompt, run_id)
+        store.append_event(
+            run_id,
+            "final",
+            {
+                "text": final_text,
+                "artifacts": [str(path) for path in files or []],
+            },
+        )
+        store.finish_run(run_id, "succeeded")
+    except Exception as exc:  # pragma: no cover - defensive
+        store.append_event(run_id, "error", {"message": str(exc)})
+        store.finish_run(run_id, "failed")
+
+
+def build_prompt(inputs: Dict[str, Any], files: Optional[List[Path]]) -> str:
+    prompt_parts = ["Task:", json.dumps(inputs, indent=2)]
+    if files:
+        prompt_parts.append("Files provided:")
+        prompt_parts.extend(str(path) for path in files)
+    return "\n".join(prompt_parts)
+
+
+def run_agent(inputs: Dict[str, Any], files: Optional[Iterable[Path]] = None) -> str:
+    """Create a run record and schedule the LangChain agent."""
+
+    file_list = list(files or [])
+    run_id = store.create_run(inputs)
+    runtime = ui.get_runtime()
+    if runtime:
+        runtime.record_run(run_id)
+
+    loop = asyncio.get_running_loop()
+    loop.create_task(_execute_run(run_id, inputs, file_list))
+    return run_id
+
+
+__all__ = ["run_agent"]

--- a/agentkit/server.py
+++ b/agentkit/server.py
@@ -1,0 +1,170 @@
+"""FastAPI server for AgentKit."""
+
+from __future__ import annotations
+
+import json
+import os
+import runpy
+from pathlib import Path
+from typing import Any, Dict, List
+
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, File, HTTPException, Request, UploadFile
+from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from sse_starlette.sse import EventSourceResponse
+
+from . import ui
+from .config import data_dir, load_config
+from .state import store
+
+
+def create_app(agent_path: str | Path | None = None) -> FastAPI:
+    agent_path = Path(agent_path or Path.cwd() / "agent_app.py").resolve()
+    templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):  # pragma: no cover - lifecycle wiring
+        data_dir()
+        load_config()
+        yield
+
+    app = FastAPI(title="AgentKit", lifespan=lifespan)
+    static_dir = Path(__file__).parent / "static"
+
+    app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+
+    app.state.agent_path = agent_path
+    app.state.templates = templates
+
+    def execute_app(runtime: ui.RuntimeContext) -> ui.RuntimeContext:
+        with ui.use_runtime(runtime):
+            runpy.run_path(str(app.state.agent_path), run_name="__agentkit__")
+        return runtime
+
+    def render_page(request: Request) -> HTMLResponse:
+        runtime = ui.RuntimeContext(mode="render")
+        execute_app(runtime)
+        page_spec = runtime.rendered_page
+        if not page_spec:
+            raise HTTPException(status_code=500, detail="Agent page did not render any content.")
+        return app.state.templates.TemplateResponse(
+            request,
+            "index.html",
+            {
+                "title": page_spec.title,
+                "description": page_spec.description,
+                "page": page_spec,
+            },
+        )
+
+    @app.get("/", response_class=HTMLResponse)
+    async def index(request: Request) -> HTMLResponse:
+        return render_page(request)
+
+    async def _persist_uploads(files: Dict[str, List[UploadFile]]) -> Dict[str, List[Dict[str, Any]]]:
+        saved: Dict[str, List[Dict[str, Any]]] = {}
+        upload_root = data_dir() / "uploads"
+        upload_root.mkdir(parents=True, exist_ok=True)
+        for field, uploads in files.items():
+            saved[field] = []
+            for upload in uploads:
+                destination = upload_root / f"{upload.filename or 'upload'}"
+                # Ensure unique name
+                counter = 1
+                while destination.exists():
+                    destination = upload_root / f"{destination.stem}-{counter}{destination.suffix}"
+                    counter += 1
+                content = await upload.read()
+                destination.write_bytes(content)
+                await upload.close()
+                file_id = store.save_upload(
+                    destination,
+                    original_name=upload.filename or "upload",
+                    mime=upload.content_type or "application/octet-stream",
+                    size=len(content),
+                )
+                saved[field].append({"path": destination, "id": file_id})
+        return saved
+
+    @app.post("/run")
+    async def start_run(request: Request) -> JSONResponse:
+        form = await request.form()
+        trigger = form.get("_trigger")
+        inputs: Dict[str, Any] = {}
+        raw_files: Dict[str, List[UploadFile]] = {}
+        for key, value in form.multi_items():
+            if key == "_trigger":
+                continue
+            if isinstance(value, UploadFile):
+                raw_files.setdefault(key, []).append(value)
+            else:
+                inputs[key] = str(value)
+        saved_files = await _persist_uploads(raw_files)
+        runtime = ui.RuntimeContext(
+            mode="execute",
+            inputs=inputs,
+            files={k: [item["path"] for item in items] for k, items in saved_files.items()},
+            trigger=trigger,
+        )
+        execute_app(runtime)
+        run_id = runtime.run_ids[-1] if runtime.run_ids else None
+        if not run_id:
+            raise HTTPException(status_code=400, detail="Agent did not start a run.")
+        return JSONResponse({"run_id": run_id})
+
+    @app.get("/stream/{run_id}")
+    async def stream(run_id: str):
+        queue = store.subscribe(run_id)
+
+        async def event_generator():
+            try:
+                for event in store.iter_events(run_id):
+                    yield format_sse(event)
+                while True:
+                    event = await queue.get()
+                    yield format_sse(event)
+            finally:
+                store.unsubscribe(run_id, queue)
+
+        return EventSourceResponse(event_generator())
+
+    @app.get("/logs/{run_id}")
+    async def logs(run_id: str) -> PlainTextResponse:
+        events = list(store.iter_events(run_id))
+        content = "\n".join(json.dumps(event) for event in events)
+        return PlainTextResponse(content, media_type="application/jsonl")
+
+    @app.get("/run/{run_id}")
+    async def get_run(run_id: str) -> JSONResponse:
+        run = store.get_run(run_id)
+        if not run:
+            raise HTTPException(status_code=404, detail="Run not found")
+        return JSONResponse(run)
+
+    @app.post("/upload")
+    async def upload(file: UploadFile = File(...)) -> JSONResponse:
+        saved = await _persist_uploads({"file": [file]})
+        entries = saved.get("file") or []
+        if not entries:
+            raise HTTPException(status_code=500, detail="Upload failed")
+        entry = entries[0]
+        return JSONResponse({"file_id": entry["id"], "path": str(entry["path"])})
+
+    return app
+
+
+def format_sse(event: Dict[str, Any]) -> Dict[str, str]:
+    return {
+        "event": event.get("type", "message"),
+        "data": json.dumps(event.get("payload", {})),
+    }
+
+
+AGENT_PATH = Path(__file__).resolve().parent.parent / "agent_app.py"
+app = create_app(Path(os.getenv("AGENTKIT_APP", str(AGENT_PATH))))
+
+
+__all__ = ["app", "create_app"]

--- a/agentkit/state.py
+++ b/agentkit/state.py
@@ -1,0 +1,196 @@
+"""Application state and persistence utilities."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sqlite3
+import time
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+DEFAULT_DB_PATH = Path(os.getenv("AGENTKIT_DATABASE", "./data/agentkit.db"))
+
+
+class RunStore:
+    """SQLite-backed run state with in-memory pub/sub for streaming."""
+
+    def __init__(self, db_path: Path | str | None = None) -> None:
+        self.db_path = Path(db_path) if db_path else DEFAULT_DB_PATH
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._queues: dict[str, List[asyncio.Queue]] = {}
+        self._init_db()
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS runs (
+                    id TEXT PRIMARY KEY,
+                    status TEXT,
+                    inputs TEXT,
+                    started_at REAL,
+                    finished_at REAL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    run_id TEXT,
+                    type TEXT,
+                    payload TEXT,
+                    ts REAL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS uploads (
+                    id TEXT PRIMARY KEY,
+                    path TEXT,
+                    original_name TEXT,
+                    mime TEXT,
+                    size INTEGER
+                )
+                """
+            )
+
+    @contextmanager
+    def _connect(self):
+        conn = sqlite3.connect(self.db_path)
+        try:
+            yield conn
+            conn.commit()
+        finally:
+            conn.close()
+
+    # Run management -----------------------------------------------------
+
+    def create_run(self, inputs: Dict[str, Any]) -> str:
+        run_id = uuid.uuid4().hex
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO runs (id, status, inputs, started_at, finished_at) VALUES (?, ?, ?, ?, ?)",
+                (run_id, "pending", json.dumps(inputs), time.time(), None),
+            )
+        return run_id
+
+    def finish_run(self, run_id: str, status: str) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE runs SET status = ?, finished_at = ? WHERE id = ?",
+                (status, time.time(), run_id),
+            )
+
+    # Events -------------------------------------------------------------
+
+    def append_event(self, run_id: str, event_type: str, payload: Dict[str, Any]) -> None:
+        record = {
+            "type": event_type,
+            "payload": payload,
+            "ts": time.time(),
+        }
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO events (run_id, type, payload, ts) VALUES (?, ?, ?, ?)",
+                (run_id, event_type, json.dumps(payload), record["ts"]),
+            )
+        queues = self._queues.get(run_id)
+        if queues:
+            for queue in list(queues):
+                try:
+                    queue.put_nowait(record)
+                except asyncio.QueueFull:  # pragma: no cover - defensive
+                    pass
+
+    def iter_events(self, run_id: str) -> Iterable[Dict[str, Any]]:
+        with self._connect() as conn:
+            for row in conn.execute(
+                "SELECT type, payload, ts FROM events WHERE run_id = ? ORDER BY id ASC",
+                (run_id,),
+            ):
+                yield {
+                    "type": row[0],
+                    "payload": json.loads(row[1]) if row[1] else {},
+                    "ts": row[2],
+                }
+
+    # Uploads ------------------------------------------------------------
+
+    def save_upload(
+        self,
+        upload_path: Path,
+        original_name: str,
+        mime: str,
+        size: int,
+    ) -> str:
+        file_id = uuid.uuid4().hex
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO uploads (id, path, original_name, mime, size) VALUES (?, ?, ?, ?, ?)",
+                (file_id, str(upload_path), original_name, mime, size),
+            )
+        return file_id
+
+    def list_uploads(self) -> List[Dict[str, Any]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT id, path, original_name, mime, size FROM uploads ORDER BY rowid DESC"
+            ).fetchall()
+        return [
+            {
+                "id": row[0],
+                "path": row[1],
+                "original_name": row[2],
+                "mime": row[3],
+                "size": row[4],
+            }
+            for row in rows
+        ]
+
+    # Streaming ----------------------------------------------------------
+
+    def subscribe(self, run_id: str) -> asyncio.Queue:
+        queue: asyncio.Queue = asyncio.Queue()
+        self._queues.setdefault(run_id, []).append(queue)
+        return queue
+
+    def unsubscribe(self, run_id: str, queue: asyncio.Queue) -> None:
+        queues = self._queues.get(run_id)
+        if not queues:
+            return
+        try:
+            queues.remove(queue)
+        except ValueError:
+            pass
+        if not queues:
+            self._queues.pop(run_id, None)
+
+    # Queries ------------------------------------------------------------
+
+    def get_run(self, run_id: str) -> Optional[Dict[str, Any]]:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT id, status, inputs, started_at, finished_at FROM runs WHERE id = ?",
+                (run_id,),
+            ).fetchone()
+        if not row:
+            return None
+        return {
+            "id": row[0],
+            "status": row[1],
+            "inputs": json.loads(row[2]) if row[2] else {},
+            "started_at": row[3],
+            "finished_at": row[4],
+        }
+
+
+store = RunStore()
+
+
+__all__ = ["RunStore", "store"]

--- a/agentkit/static/app.js
+++ b/agentkit/static/app.js
@@ -1,0 +1,115 @@
+(function () {
+  const form = document.getElementById("agent-form");
+  const triggerField = document.getElementById("trigger-field");
+  const consoleEl = document.getElementById("console");
+  const outputEl = document.getElementById("final-output");
+  const artifactsEl = document.getElementById("artifacts");
+
+  let currentStream = null;
+
+  function resetPanels() {
+    consoleEl.textContent = "";
+    outputEl.textContent = "";
+    artifactsEl.innerHTML = "";
+  }
+
+  function appendConsole(text) {
+    consoleEl.textContent += text;
+    consoleEl.scrollTop = consoleEl.scrollHeight;
+  }
+
+  function appendToolEvent(prefix, payload) {
+    const block = document.createElement("div");
+    block.className = "tool-event";
+    block.innerHTML = `<strong>${prefix}</strong><pre>${JSON.stringify(payload, null, 2)}</pre>`;
+    consoleEl.appendChild(block);
+    consoleEl.scrollTop = consoleEl.scrollHeight;
+  }
+
+  function appendArtifacts(paths) {
+    artifactsEl.innerHTML = "";
+    paths.forEach((item) => {
+      const li = document.createElement("li");
+      li.textContent = item;
+      artifactsEl.appendChild(li);
+    });
+  }
+
+  function openStream(runId) {
+    if (currentStream) {
+      currentStream.close();
+    }
+    const url = `/stream/${runId}`;
+    const source = new EventSource(url);
+    currentStream = source;
+
+    source.addEventListener("token", (event) => {
+      const data = JSON.parse(event.data);
+      appendConsole(data.text || "");
+    });
+
+    source.addEventListener("tool_start", (event) => {
+      const data = JSON.parse(event.data);
+      appendToolEvent("➡️ Tool start", data);
+    });
+
+    source.addEventListener("tool_end", (event) => {
+      const data = JSON.parse(event.data);
+      appendToolEvent("✅ Tool end", data);
+    });
+
+    source.addEventListener("final", (event) => {
+      const data = JSON.parse(event.data);
+      outputEl.textContent = data.text || "";
+      if (Array.isArray(data.artifacts)) {
+        appendArtifacts(data.artifacts);
+      }
+      source.close();
+    });
+
+    source.addEventListener("error", (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        appendToolEvent("❌ Error", data);
+      } catch (err) {
+        appendConsole("\n[error]\n");
+      }
+      source.close();
+    });
+  }
+
+  if (form) {
+    form.addEventListener("click", (event) => {
+      const target = event.target;
+      if (target.matches("button[data-trigger]")) {
+        triggerField.value = target.dataset.trigger;
+      }
+    });
+
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      if (!triggerField.value) {
+        return;
+      }
+      resetPanels();
+      const formData = new FormData(form);
+      try {
+        const response = await fetch("/run", {
+          method: "POST",
+          body: formData,
+        });
+        if (!response.ok) {
+          const message = await response.text();
+          appendToolEvent("❌ Error", { message });
+          return;
+        }
+        const payload = await response.json();
+        if (payload.run_id) {
+          openStream(payload.run_id);
+        }
+      } catch (error) {
+        appendToolEvent("❌ Error", { message: error.message });
+      }
+    });
+  }
+})();

--- a/agentkit/templates/base.html
+++ b/agentkit/templates/base.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>{{ title or "AgentKit" }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      body {
+        margin: 0;
+        background: #0f1116;
+        color: #f2f4f8;
+      }
+      a {
+        color: #9ad0ff;
+      }
+      header {
+        padding: 1.5rem 2rem;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+      }
+      main {
+        padding: 2rem;
+        display: flex;
+        gap: 2rem;
+      }
+      .column {
+        flex: 1;
+        background: rgba(255, 255, 255, 0.05);
+        border-radius: 12px;
+        padding: 1.5rem;
+        overflow: auto;
+      }
+      .inputs {
+        max-width: 360px;
+        flex: 0 0 360px;
+      }
+      label {
+        display: block;
+        font-size: 0.9rem;
+        margin-bottom: 0.25rem;
+      }
+      input[type="text"],
+      textarea,
+      input[type="file"] {
+        width: 100%;
+        padding: 0.5rem 0.75rem;
+        border-radius: 8px;
+        border: 1px solid rgba(255, 255, 255, 0.15);
+        background: rgba(15, 17, 22, 0.9);
+        color: inherit;
+        margin-bottom: 1rem;
+      }
+      button {
+        background: linear-gradient(120deg, #5b8fff, #7c4dff);
+        border: none;
+        color: white;
+        padding: 0.75rem 1.25rem;
+        border-radius: 8px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.1s ease;
+      }
+      button:hover {
+        transform: translateY(-1px);
+      }
+      pre {
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        font-family: "JetBrains Mono", monospace;
+      }
+      .console {
+        min-height: 200px;
+        background: rgba(0, 0, 0, 0.45);
+        padding: 1rem;
+        border-radius: 8px;
+        margin-bottom: 1rem;
+      }
+      .artifacts ul {
+        list-style: none;
+        padding-left: 0;
+      }
+      .artifacts li {
+        margin-bottom: 0.5rem;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>{{ title or "AgentKit" }}</h1>
+      {% if description %}
+      <p>{{ description }}</p>
+      {% endif %}
+    </header>
+    {% block content %}{% endblock %}
+    <script src="/static/app.js" defer></script>
+  </body>
+</html>

--- a/agentkit/templates/index.html
+++ b/agentkit/templates/index.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block content %}
+<main>
+  <section class="column inputs">
+    <form id="agent-form">
+      {% for component in page.components %}
+        {% if component.type == 'text' %}
+          <label for="{{ component.id }}">{{ component.props.label }}</label>
+          <input type="text" id="{{ component.id }}" name="{{ component.id }}" placeholder="{{ component.props.placeholder }}" />
+        {% elif component.type == 'file' %}
+          <label for="{{ component.id }}">{{ component.props.label }}</label>
+          <input type="file" id="{{ component.id }}" name="{{ component.id }}" {% if component.props.multiple %}multiple{% endif %} {% if component.props.accept %}accept="{{ component.props.accept | join(',') }}"{% endif %} />
+        {% elif component.type == 'button' %}
+          <button type="submit" data-trigger="{{ component.id }}">{{ component.props.label }}</button>
+        {% endif %}
+      {% endfor %}
+      <input type="hidden" name="_trigger" id="trigger-field" />
+    </form>
+  </section>
+  <section class="column">
+    <div class="console" id="console"></div>
+    <div class="output">
+      <h3>Output</h3>
+      <pre id="final-output"></pre>
+    </div>
+    <div class="artifacts">
+      <h3>Artifacts</h3>
+      <ul id="artifacts"></ul>
+    </div>
+  </section>
+</main>
+{% endblock %}

--- a/agentkit/ui.py
+++ b/agentkit/ui.py
@@ -1,0 +1,184 @@
+"""Minimal UI description DSL for AgentKit apps."""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class Component:
+    type: str
+    id: str
+    props: Dict[str, Any]
+
+
+@dataclass
+class PageSpec:
+    title: str
+    description: Optional[str] = None
+    components: List[Component] = field(default_factory=list)
+
+    def add(self, component: Component) -> None:
+        self.components.append(component)
+
+
+class RuntimeContext:
+    """Holds runtime values for executing the AgentKit DSL."""
+
+    def __init__(
+        self,
+        mode: str = "render",
+        inputs: Optional[Dict[str, Any]] = None,
+        files: Optional[Dict[str, Any]] = None,
+        trigger: Optional[str] = None,
+    ) -> None:
+        self.mode = mode
+        self.inputs = inputs or {}
+        self.files = files or {}
+        self.trigger = trigger
+        self.current_page: Optional[PageSpec] = None
+        self.rendered_page: Optional[PageSpec] = None
+        self._slug_counts: Dict[str, int] = {}
+        self.run_ids: List[str] = []
+
+    # Component helpers -------------------------------------------------
+
+    def _slugify(self, label: str, prefix: str) -> str:
+        base = re.sub(r"[^a-z0-9]+", "-", label.lower()).strip("-")
+        if not base:
+            base = prefix
+        key = f"{prefix}-{base}"
+        count = self._slug_counts.get(key, 0) + 1
+        self._slug_counts[key] = count
+        if count > 1:
+            return f"{base}-{count}"
+        return base
+
+    def register(self, type_: str, label: str, props: Optional[Dict[str, Any]] = None) -> str:
+        if not self.current_page:
+            raise RuntimeError("ui.page() must be active before adding components")
+        component_id = props.get("id") if props and "id" in props else self._slugify(label, type_)
+        component = Component(type=type_, id=component_id, props={"label": label, **(props or {})})
+        self.current_page.add(component)
+        return component_id
+
+    def resolve_value(self, component_id: str, kind: str) -> Any:
+        if kind == "file":
+            return self.files.get(component_id, [])
+        if kind == "button":
+            return self.trigger == component_id
+        return self.inputs.get(component_id)
+
+    def set_page(self, page: PageSpec) -> None:
+        self.current_page = page
+        self.rendered_page = page
+
+    def record_run(self, run_id: str) -> None:
+        self.run_ids.append(run_id)
+
+
+_runtime_var: contextvars.ContextVar[Optional[RuntimeContext]] = contextvars.ContextVar(
+    "agentkit_runtime", default=None
+)
+
+
+@contextlib.contextmanager
+def page(title: str, description: str | None = None):
+    runtime = ensure_runtime()
+    previous_page = runtime.current_page
+    spec = PageSpec(title=title, description=description)
+    runtime.set_page(spec)
+    try:
+        yield spec
+    finally:
+        runtime.current_page = previous_page
+
+
+class ValueRef:
+    def __init__(self, component_id: str, kind: str, default: Any = None):
+        self.component_id = component_id
+        self.kind = kind
+        self.default = default
+
+    @property
+    def value(self) -> Any:
+        runtime = get_runtime()
+        if not runtime:
+            return self.default
+        value = runtime.resolve_value(self.component_id, self.kind)
+        return value if value is not None else self.default
+
+    def __str__(self) -> str:
+        value = self.value
+        return "" if value is None else str(value)
+
+    def __bool__(self) -> bool:  # pragma: no cover - simple proxy
+        value = self.value
+        if isinstance(value, list):
+            return bool(value)
+        return bool(value)
+
+
+def text_input(label: str, placeholder: str = "") -> ValueRef:
+    runtime = ensure_runtime()
+    component_id = runtime.register("text", label, {"placeholder": placeholder})
+    return ValueRef(component_id, kind="text", default="")
+
+
+def file_uploader(
+    label: str,
+    accept: Optional[List[str]] = None,
+    multiple: bool = True,
+) -> ValueRef:
+    runtime = ensure_runtime()
+    props = {"accept": accept or [], "multiple": multiple}
+    component_id = runtime.register("file", label, props)
+    return ValueRef(component_id, kind="file", default=[])
+
+
+def button(label: str) -> bool:
+    runtime = ensure_runtime()
+    component_id = runtime.register("button", label)
+    return bool(runtime.resolve_value(component_id, "button"))
+
+
+def chat() -> None:
+    runtime = ensure_runtime()
+    runtime.register("chat", "Conversation", {})
+
+
+def get_runtime() -> Optional[RuntimeContext]:
+    return _runtime_var.get()
+
+
+def ensure_runtime() -> RuntimeContext:
+    runtime = _runtime_var.get()
+    if runtime is None:
+        runtime = RuntimeContext()
+        _runtime_var.set(runtime)
+    return runtime
+
+
+@contextlib.contextmanager
+def use_runtime(runtime: RuntimeContext):
+    token = _runtime_var.set(runtime)
+    try:
+        yield runtime
+    finally:
+        _runtime_var.reset(token)
+
+
+__all__ = [
+    "RuntimeContext",
+    "page",
+    "text_input",
+    "file_uploader",
+    "button",
+    "chat",
+    "use_runtime",
+    "get_runtime",
+]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,34 @@
+app = "agentkit-app"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "8080"
+
+[[services]]
+  internal_port = 8080
+  protocol = "tcp"
+
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+
+[checks]
+  [checks.primary]
+    port = 8080
+    type = "http"
+    interval = "30s"
+    timeout = "10s"
+    grace_period = "30s"
+
+[experimental]
+  auto_rollback = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,26 @@ description = "Minimal Streamlit-for-Agents framework"
 authors = [{ name = "AgentKit" }]
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = []
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]",
+    "jinja2",
+    "python-dotenv",
+    "pydantic",
+    "pyyaml",
+    "langchain",
+    "langchain-community",
+    "langchain-openai",
+    "sse-starlette",
+    "aiofiles",
+    "sqlalchemy",
+    "python-multipart",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+]
 
 [project.scripts]
 agentkit = "agentkit.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "agentkit"
+version = "0.1.0"
+description = "Minimal Streamlit-for-Agents framework"
+authors = [{ name = "AgentKit" }]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.scripts]
+agentkit = "agentkit.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["agentkit"]
+
+[tool.setuptools.package-data]
+"agentkit" = ["templates/*.html", "static/*.js"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+fastapi
+uvicorn[standard]
+jinja2
+python-dotenv
+pydantic
+pyyaml
+langchain
+langchain-community
+langchain-openai
+sse-starlette
+aiofiles
+sqlalchemy
+python-multipart

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ sse-starlette
 aiofiles
 sqlalchemy
 python-multipart
+pytest

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from fastapi.testclient import TestClient
+
+from agentkit import ui
+from agentkit.server import create_app
+from agentkit.state import store
+
+
+def test_homepage_and_run(monkeypatch):
+    app_path = Path(__file__).resolve().parent.parent / "agent_app.py"
+
+    def fake_run_agent(inputs, files=None):
+        run_id = store.create_run(inputs)
+        runtime = ui.get_runtime()
+        if runtime:
+            runtime.record_run(run_id)
+        store.append_event(run_id, "final", {"text": "ok"})
+        store.finish_run(run_id, "succeeded")
+        return run_id
+
+    monkeypatch.setattr("agentkit.run_agent", fake_run_agent)
+    monkeypatch.setattr("agentkit.runner.run_agent", fake_run_agent)
+
+    client = TestClient(create_app(app_path))
+
+    response = client.get("/")
+    assert response.status_code == 200
+
+    response = client.post(
+        "/run",
+        data={
+            "task": "hello",
+            "_trigger": "run-agent",
+        },
+    )
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+
+    run_meta = client.get(f"/run/{run_id}")
+    assert run_meta.status_code == 200
+    assert run_meta.json()["status"] == "succeeded"
+
+    logs = client.get(f"/logs/{run_id}")
+    assert logs.status_code == 200
+    assert "final" in logs.text


### PR DESCRIPTION
## Summary
- implement AgentKit package with LangChain runner, FastAPI server, UI DSL, and SQLite-backed state management
- add server-rendered templates, streaming frontend assets, default agent config, CLI entry point, and example app
- provide packaging metadata, Dockerfile, documentation, and smoke tests for the HTTP endpoints

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d5f18b8f048326bf70a84be6b0d987